### PR TITLE
Chore: Add LICENSE file to created package

### DIFF
--- a/create_package.py
+++ b/create_package.py
@@ -275,6 +275,11 @@ def get_base_files_mapping() -> List[FileMapping]:
             "package.py"
         )
     ]
+    # Add license file to package if exists
+    license_path = os.path.join(CURRENT_ROOT, "LICENSE")
+    if os.path.exists(license_path):
+        filepaths_to_copy.append((license_path, "LICENSE"))
+
     # Go through server, private and public directories and find all files
     for dirpath in (SERVER_ROOT, PRIVATE_ROOT, PUBLIC_ROOT):
         if not os.path.exists(dirpath):

--- a/create_package.py
+++ b/create_package.py
@@ -246,15 +246,19 @@ def get_client_files_mapping() -> List[Tuple[str, str]]:
     Returns:
         list[tuple[str, str]]: List of path mappings to copy. The destination
             path is relative to expected output directory.
-    """
 
+    """
     # Add client code content to zip
     client_code_dir: str = os.path.join(CLIENT_ROOT, ADDON_CLIENT_DIR)
-
-    return [
+    mapping = [
         (path, os.path.join(ADDON_CLIENT_DIR, sub_path))
         for path, sub_path in find_files_in_subdir(client_code_dir)
     ]
+
+    license_path = os.path.join(CURRENT_ROOT, "LICENSE")
+    if os.path.exists(license_path):
+        mapping.append((license_path, f"{ADDON_CLIENT_DIR}/LICENSE"))
+    return mapping
 
 
 def get_client_zip_content(log) -> io.BytesIO:


### PR DESCRIPTION
## Changelog Description
Added `LICENSE` file to created package if is available.

## Additional info
Created package has no information about it's licensing. A person has to go to a corresponding repository, but usually information about repository is not available in the package.


## Testing notes:
1. Validate if it makes sense to add license to package.