### PR TITLE
Create version.py in client directory if missing

### DIFF
--- a/create_package.py
+++ b/create_package.py
@@ -207,8 +207,7 @@ def update_client_version(logger):
         CLIENT_ROOT, ADDON_CLIENT_DIR, "version.py"
     )
     if not os.path.exists(version_path):
-        logger.debug("Did not find version.py in client directory")
-        return
+        logger.debug("Creating version.py in client directory")
 
     logger.info("Updating client version")
     with open(version_path, "w") as stream:


### PR DESCRIPTION
Automatically creating this file is more straight forward.

## Changelog Description
Create `version.py` if missing in client directory.

## Testing notes:
1. Remove any `version.py` from client directory
2. Make sure `client_dir` is set to your addon's name in `package.py`
3. Run `python create_package.py`
